### PR TITLE
feat: Elasticsearch 설정 및 주차장 검색 DAO 계층 추가,테스트

### DIFF
--- a/src/main/kotlin/com/parking/parking_lot/common/ElasticsearchConfig.kt
+++ b/src/main/kotlin/com/parking/parking_lot/common/ElasticsearchConfig.kt
@@ -1,53 +1,102 @@
 package com.parking.parking_lot.common
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient
-import co.elastic.clients.json.JsonData
+import co.elastic.clients.json.jackson.JacksonJsonpMapper
 import co.elastic.clients.transport.rest_client.RestClientTransport
 import org.apache.http.HttpHost
+import org.apache.http.auth.AuthScope
+import org.apache.http.auth.UsernamePasswordCredentials
+import org.apache.http.impl.client.BasicCredentialsProvider
 import org.elasticsearch.client.RestClient
-import org.elasticsearch.client.RestClientBuilder
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories
-import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManager
 import javax.net.ssl.X509TrustManager
 
 @Configuration
-@EnableElasticsearchRepositories
-class ElasticsearchConfig {
+class ElasticsearchConfig(
+    @Value("\${spring.elasticsearch.password}") private val password: String,//생성자주입
 
-    @Value("\${spring.elasticsearch.uris}")
-    lateinit var url: String
+    @Value("\${spring.elasticsearch.username}") private val username: String,
 
-    @Value("\${spring.elasticsearch.password}")
-    lateinit var password: String
+    @Value("\${spring.elasticsearch.host}") private  val host : String,
 
-    @Bean
-    fun elasticsearchRestClient(): RestClient {
+    @Value("\${spring.elasticsearch.port}") private val port : Int,
 
-        // TrustManager 설정 (모든 인증서 신뢰)
-        val trustAllCertificates: TrustManager = object : X509TrustManager {
-            override fun getAcceptedIssuers(): Array<X509Certificate>? = null
-            override fun checkClientTrusted(certificates: Array<X509Certificate>, authType: String) {}
-            override fun checkServerTrusted(certificates: Array<X509Certificate>, authType: String) {}
-        }
+) {
 
-        // SSL 컨텍스트 생성
-        val sslContext: SSLContext = SSLContext.getInstance("TLS")
-        sslContext.init(null, arrayOf(trustAllCertificates), java.security.SecureRandom())
+    /**
+     * SSL 인증 검사를 비활성화하는 메서드입니다.
+     *
+     * - 개발환경에서만 사용합니다.
+     *
+     * @return SSLContext 객체 (모든 인증서를 신뢰하는 설정 적용)
+     */
+    fun disableSSLVerification(): SSLContext {
+        val trustAllCertificates = arrayOf<TrustManager>(
+            object : X509TrustManager {
+                //클라이언트 인증 비활성화
+                override fun checkClientTrusted(chain: Array<java.security.cert.X509Certificate>?, authType: String?) {}
+                //서버 인증 비활성화
+                override fun checkServerTrusted(chain: Array<java.security.cert.X509Certificate>?, authType: String?) {}
+                //CA 목록 null 반환, 모든기관 신뢰
+                override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate>? = null
+            }
+        )
 
-        // RestClientBuilder 생성
-        val builder: RestClientBuilder = RestClient.builder(HttpHost("localhost", 9200, "https"))
+        //TSL 프로토콜 사용하는 SSLContext 객체 생성
+        val sslContext = SSLContext.getInstance("TLS")
+        // TrustManager를 사용하여 SSLContext 초기화 (모든 인증서 신뢰)
+        sslContext.init(null, trustAllCertificates, java.security.SecureRandom())
 
-        builder.setHttpClientConfigCallback { httpClientBuilder ->
-            httpClientBuilder.setSSLContext(sslContext)  // SSL 검증 비활성화
-            httpClientBuilder.setSSLHostnameVerifier { _, _ -> true }  // 호스트 이름 검증 비활성화
-        }
-
-        return builder.build()  // RestClient 반환
+        //SSL 인증 비활성화된 Context 반환
+        return sslContext
     }
 
+
+    /**
+     * Elasticsearch의 `RestClient`를 생성하는 Bean입니다.
+     *
+     * - Elasticsearch 서버와의 통신시 사용되는  REST 클라이언트입니다.
+     * - 인증 정보를 설정하여 Elasticsearch 서버와의 보안 연결을 유지합니다.
+     * - SSL 인증을 비활성화하여 HTTPS 연결 시 인증서 검사를 수행하지 않습니다.(개발환경에서만 사용)
+     *
+     * @return `RestClient` 객체
+     */
+    @Bean
+    fun restClient(): RestClient {
+        val credentialsProvider = BasicCredentialsProvider().apply {
+            setCredentials(AuthScope.ANY, UsernamePasswordCredentials(username ,password))//엘라스틱서치 인증 정보
+        }
+
+        return RestClient.builder(
+            HttpHost(host, port, "https") // HTTPS 사용
+        )
+            .setHttpClientConfigCallback { httpClientBuilder ->
+                httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)//기본인증서사용
+                    .setSSLContext(disableSSLVerification()) // SSL 검증 비활성화
+            }
+            .build()
+    }
+
+    /**
+     * Elasticsearch 클라이언트를 생성하는 Bean입니다.
+     *
+     * - [RestClient]를 이용하여 [ElasticsearchClient]를 생성합니다.
+     * - JSON 직렬화 및 역직렬화를 위해 [JacksonJsonpMapper]를 사용합니다.
+     *
+     * @param restClient `RestClient` 객체 (Spring Bean으로 주입됨).
+     * @return [ElasticsearchClient] 객체
+     */
+    @Bean
+    fun elasticsearchClient(restClient: RestClient): ElasticsearchClient {
+        //Elasticsearch 요청/응답 직렬화,역직렬화
+        val transport = RestClientTransport(
+            restClient,
+            JacksonJsonpMapper()//JSON 변환 설정
+        )
+        return ElasticsearchClient(transport)
+    }
 }

--- a/src/main/kotlin/com/parking/parking_lot/parking/repository/ParkingElasticSearchRepository.kt
+++ b/src/main/kotlin/com/parking/parking_lot/parking/repository/ParkingElasticSearchRepository.kt
@@ -1,9 +1,28 @@
 package com.parking.parking_lot.parking.repository
 
 import com.parking.parking_lot.parking.ParkingDocument
+import org.springframework.data.elasticsearch.core.geo.GeoPoint
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 
 
 interface ParkingElasticSearchRepository : ElasticsearchRepository<ParkingDocument,String>{
+
+
+    /**
+     * 주차장 이름에 특정 문자열을 포함하는 [ParkingDocument] 객체들을 Elasticsearch 에서 검색합니다.
+     *
+     * @param name 검색할 부분 문자열. 예를 들어, "보라매"이 입력되면 "보라매 공원 주차장" 등이 검색됩니다.
+     * @return 이름 필드에 [name]을 포함하는 [ParkingDocument] 리스트.
+     */
+    fun findByNameContaining(name:String): List<ParkingDocument>//name 필드에 대해 부분검색
+
+    /**
+     * 지정한 좌표 [location] 근처에 위치한 [ParkingDocument] 객체들을 Elasticsearch에서 검색합니다.
+     *
+     * @param location 검색의 중심이 되는 좌표 정보.
+     * @param distance [location]을 중심으로 검색할 반경 거리 [String] 타입 (예: "5km").
+     * @return 지정된 좌표 근처의 주차장 문서들의 [ParkingDocument] 리스트.
+     */
+    fun findByLocationNear(location: GeoPoint, distance: String): List<ParkingDocument> // 좌표 기반 검색
 
 }

--- a/src/test/kotlin/com/parking/parking_lot/parking/repository/ParkingElasticSearchRepositoryTest.kt
+++ b/src/test/kotlin/com/parking/parking_lot/parking/repository/ParkingElasticSearchRepositoryTest.kt
@@ -1,0 +1,45 @@
+package com.parking.parking_lot.parking.repository
+
+import com.parking.parking_lot.ParkingLotApplication
+import com.parking.parking_lot.parking.ParkingDocument
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.elasticsearch.core.geo.GeoPoint
+
+
+@SpringBootTest(classes = [ParkingLotApplication::class]) // HTTPS 설정 포함된 Spring Boot Test 실행
+
+class ParkingElasticSearchRepositoryTest {
+
+    @Autowired
+    lateinit var parkingElasticSearchRepository: ParkingElasticSearchRepository
+
+    @BeforeEach
+    fun setup() {
+        //테스트 Document 생성
+        val parking1 = ParkingDocument(id = 1, name = "Test Parking Lot", address = "주소",location = GeoPoint(37.5665, 126.9780))
+        val parking2 = ParkingDocument(id = 2, name = "Nearby Parking",address = "주소", location = GeoPoint(37.5675, 126.9790))
+
+        //테스트 Document 저장
+        parkingElasticSearchRepository.saveAll(listOf(parking1, parking2))
+    }
+
+    @Test
+    fun `should return results when searching by name`() {
+        val result = parkingElasticSearchRepository.findByNameContaining("Test")
+
+        assertEquals(1, result.size)
+        assertEquals("Test Parking Lot", result.first().name)//이름이 같은지 검증
+    }
+
+    @Test
+    fun `should return results when searching by location`() {
+        val location = GeoPoint(37.5665, 126.9780)//테스트 좌표객체
+        val result = parkingElasticSearchRepository.findByLocationNear(location, "5km")//5km 이내 탐색
+
+        assertEquals(2, result.size) // 5km 내에 두 개의 주차장이 있다고 가정
+    }
+}


### PR DESCRIPTION
- ElasticsearchConfig
  - Elasticsearch 연결설정 Class
  - Elasticsearch 클라이언트 및 RestClient Bean 등록
  - HTTPS 연결 및 인증 설정 (개발 환경에서 SSL 검증 비활성화)

- ParkingElasticSearchRepository
  - ElasticsearchRepository 상속받음
  - 주차장 이름으로 부분 검색 (findByNameContaining)
  - 좌표 기반 검색 (findByLocationNear)

- ParkingElasticSearchRepositoryTest
  - Spring boot 및 Elasticsearch 통합 테스트
  - 주차장 이름 검색 테스트 (`findByNameContaining`)
  - 좌표 기반 검색 테스트 (`findByLocationNear`)
  - 테스트 데이터 자동 생성 및 저장